### PR TITLE
Gulpfile.js processImages remove .ico exception

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,7 +220,7 @@ function copyImagesProd() {
 }
 
 function processImages() {
-	return src(['./dist/assets/img/**', '!./dist/assets/img/**/*.ico'])
+	return src(['./dist/assets/img/**'])
 		.pipe(plumber({ errorHandler: onError }))
 		.pipe(
 			imagemin([imagemin.svgo({ plugins: [{ removeViewBox: true }] })], {


### PR DESCRIPTION
the **.ico** was not getting copied to dist folder when u  `npm run prod`